### PR TITLE
Add issuer field to the generated URL

### DIFF
--- a/qrcode.js
+++ b/qrcode.js
@@ -15,6 +15,8 @@ function makeURI() {
 
 	uri += encodeURIComponent(account);
 	uri += "?secret=" + secret;
+	if (issuer.length > 0)
+		uri += '&issuer=' + issuer;
 	uri += "&algorithm=" + algorithm;
 	uri += "&digits=" + digits;
 	uri += "&period=" + period;


### PR DESCRIPTION
Google Authenticator's spec has an 'issuer' field. Add support for it.

https://github.com/google/google-authenticator/wiki/Key-Uri-Format

```
otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example
```
