### PR TITLE
update/add links

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,16 +79,16 @@
 				 <a href="qrcode.html">QR code generator</a>.</p>
 
 			<p>FreeOTP implements open standards:
-				 <a href="http://www.ietf.org/rfc/rfc4226.txt">HOTP</a> and
-				 <a href="http://www.ietf.org/rfc/rfc6238.txt">TOTP</a>. This means that no
+				 <a href="https://www.ietf.org/rfc/rfc4226.txt">HOTP</a> and
+				 <a href="https://www.ietf.org/rfc/rfc6238.txt">TOTP</a>. This means that no
 				 proprietary server-side component is necessary: use any server-side
 				 component that implements these standards. We recommend
-				 <a href="http://www.freeipa.org">FreeIPA</a>.</p>
+				 <a href="https://www.freeipa.org/">FreeIPA</a>.</p>
 
       <p>FreeOTP is sponsored and officially published by
          <a href="https://www.redhat.com">Red Hat</a>. Pull requests
-         <a href="https://github.com/freeotp">on GitHub</a> are welcome under
-         the Apache 2.0 license. Feel free to review our
+         <a href="https://github.com/freeotp">on GitHub</a> are welcome under the
+         <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>. Feel free to review our
          <a href="privacy.html">privacy policy</a>.</p>
 		</footer>
   </body>


### PR DESCRIPTION
1. prefer HTTPS over HTTP
HTTPS is supported, see:
- https://www.ietf.org/rfc/rfc4226.txt
- https://www.ietf.org/rfc/rfc6238.txt
- https://www.freeipa.org/

2. add link to "Apache License 2.0":
https://www.apache.org/licenses/LICENSE-2.0

3. fix license name:
"Apache License 2.0", see https://www.apache.org/licenses/