### PR TITLE
update the iOS link to apps.a.c

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 
 		<main>
 			<section id="ios">
-				<a class="screenshot" href="https://itunes.apple.com/us/app/freeotp-authenticator/id872559395?mt=8">
+				<a class="screenshot" href="https://apps.apple.com/us/app/freeotp-authenticator/id872559395?mt=8">
           <img src="img/ios.png" alt="iOS" />
         </a>
 				<a class="store" alt="iOS App" href="https://itunes.apple.com/us/app/freeotp-authenticator/id872559395?mt=8">


### PR DESCRIPTION
It looks like itunes domain is just a redirect these days. For a moment it also didn't load at all for me.